### PR TITLE
Update package.json - added license Apache-2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "name": "streamich",
     "url": "https://github.com/streamich"
   },
+  "license": "Apache-2.0",
   "homepage": "https://github.com/streamich/tree-dump",
   "repository": "streamich/tree-dump",
   "funding": {


### PR DESCRIPTION
Added a license property to package.json to fix issue with missing license in BlackDuck

solves issue #4 