### PR TITLE
fix: publish license type to NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,13 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "High-performance (binary) tree and sorted map implementation (AVL, Splay, Radix, Red-Black)",
   "author": {
     "name": "streamich",
     "url": "https://github.com/streamich"
   },
+  "license": "Apache-2.0",
   "homepage": "https://github.com/streamich/tree-dump",
   "repository": "streamich/tree-dump",
   "funding": {


### PR DESCRIPTION
fixes https://github.com/streamich/tree-dump/issues/4

@streamich would be awesome if we could publish this package with license field in pkg json so that dependency scanners stop complaining about "unclear licensing". I'm using memfs of which this package is a dependency, hence the issue.